### PR TITLE
fix: extend `react` version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "main": "src/reactTimeout.js",
   "dependencies": {
     "object-assign": "^4.0.1",
-    "react": "^0.13.3"
+    "react": ">=0.13.3 <0.15.0"
   }
 }


### PR DESCRIPTION
This module works, as is, with React 0.14.