### PR TITLE
Allow access to the wrapped instance through `component.wrappedInstance`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ class Example extends React.Component {
 }
 ```
 
+## To access the wrapped instance
+If you need access to the component wrapped by `ReactTimeout`, use `component.getWrappedInstance()`.
+
 # Something similar
 
 ## [react-timer-mixin](https://github.com/reactjs/react-timer-mixin)

--- a/src/reactTimeout.js
+++ b/src/reactTimeout.js
@@ -75,6 +75,10 @@ var createReactTimeout = function (React) {
         cloneArray(this[_rafs]).forEach(this.cancelAnimationFrame)
       },
 
+      getWrappedInstance() {
+        return this.wrappedInstance;
+      },
+
       render: function () {
         return React.createElement(
           SourceComponent,
@@ -82,6 +86,7 @@ var createReactTimeout = function (React) {
             {},
             this.props,
             {
+              ref: (component) => { this.wrappedInstance = component; },
               setTimeout: this.setTimeout,
               clearTimeout: this.clearTimeout,
 

--- a/test/wrappedInstance.jsx
+++ b/test/wrappedInstance.jsx
@@ -1,0 +1,17 @@
+import React, { Component } from "react";
+import ReactTimeout from "..";
+import { renderIntoDocument } from "react-dom/test-utils";
+
+describe("wrapped instance", () => {
+  class Plain extends Component {
+    instanceMethod() {}
+    render() { return <div />; }
+  }
+  const Timed = ReactTimeout(Plain);
+  const rendering = renderIntoDocument(<Timed />);
+
+  it('can access the wrapped instance', () => {
+    rendering.getWrappedInstance().instanceMethod();
+  });
+
+});


### PR DESCRIPTION
This is important if you want to access instance methods on a component
which is wrapped by `ReactTimeout`. As an example, imagine you have an
input component that needs to use `ReactTimeout`, but you also want to
be able to focus the input.

The interface is similar to `react-redux` - see:
https://github.com/reactjs/react-redux/blob/fd436b1e024c4194d3f44dfcef8e30fd24a99a1a/src/components/connectAdvanced.js#:181

Test plan: Added a unit test.