### PR TITLE
JSDOM requires a specific version to work

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "chai": "^4.0.0",
     "chai-immutable": "^1.5.3",
     "immutable": "^3.8.0",
-    "jsdom": "^11.0.0",
+    "jsdom": "11.11.0",
     "mocha": "^5.0.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2"


### PR DESCRIPTION
Later versions complain about a security error which is not an issue in testing.

Closes #33 
Closes #34 