### PR TITLE
Update hoist-non-react-statics to version 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "create-react-class": "^15.5.2",
-    "hoist-non-react-statics": "^2.3.1",
+    "hoist-non-react-statics": "^3.0.1",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This version doesn't support React 13.x so that will result in some breaking changes.

Closes #36 
Closes #32 