### PR TITLE
feat: Check that the source is valid ES5

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "esversion": 5,
+  "asi": true
+}

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "npm run standard && npm test"
+      "pre-push": "npm run standard && npm run check-es5 && npm test"
     }
   },
   "scripts": {
+    "check-es5": "jshint src/*.js",
     "test": "jest",
     "standard": "standard"
   },
@@ -55,6 +56,7 @@
     "husky": "1.3.1",
     "jest": "24.1.0",
     "jest-dom": "3.1.2",
+    "jshint": "2.10.1",
     "react": "16.8.3",
     "react-dom": "16.8.3",
     "react-test-renderer": "16.8.3",


### PR DESCRIPTION
- This is added as a pre-push hook.
- The source is already ES5, but this will help prevent any _accidental ES6_